### PR TITLE
Add example code for various Upstox API functionalities

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,15 +1,45 @@
-# PHP Sample Implementation
+# Upstox Developer API – Example Code
 
-## Websocket
+This folder contains **ready-to-use PHP samples** for the [Upstox API](https://upstox.com/developer/api-documentation/open-api). Each example shows how to call the API using the official [Upstox PHP SDK](https://packagist.org/packages/upstox/upstox-php-sdk) (`upstox/upstox-php-sdk`).
 
-### Market stream feed
+## Why use these samples?
 
-PHP script to connect to the Upstox Websocket API for streaming live market data. It fetches market data for a list of instrument keys and decodes the incoming protobuf data to a JSON format.
+- **Quick start** — Copy-paste examples for common flows (login, orders, market data, portfolio).
+- **Correct usage** — Request/response patterns, error handling, and API version usage as recommended by Upstox.
+- **Reference** — See how to structure `PlaceOrderRequest`, historical data params, and other API payloads.
 
-[Market updates using Upstox's websocket](websocket/market_data/v3)
+Use these samples to build trading apps, dashboards, or integrations without guessing request shapes or SDK usage.
 
-### Porfolio stream feed
+## Prerequisites
 
-PHP script to connect to the Upstox WebSocket API for streaming live order updates. It fetches the order updates and prints them to the console.
+- **PHP** 7.4+
+- **SDK**: `composer require upstox/upstox-php-sdk`
+- **Upstox developer account** and API credentials (client ID, client secret, redirect URI).
+- **Access token** for authenticated APIs (obtain via [Login API](login/) samples).
 
-[Order updates using Upstox's websocket](websocket/order_updates/)
+For full setup, sandbox mode, and auth flow, see the main [Upstox PHP SDK README](../README.md) in the repo root.
+
+## Folder structure
+
+Samples are grouped by API area. Each `.md` file contains one or more PHP snippets you can run after replacing placeholders like `{your_access_token}` and `{your_client_id}`.
+
+| Folder | Description |
+|--------|-------------|
+| [**login/**](login/) | Authentication: get token from auth code, access-token request, logout. |
+| [**user/**](user/) | User profile, fund and margin details. |
+| [**orders/**](orders/) | Order lifecycle: place (single/multi, v2 & v3), modify, cancel, order book, order details, order history, trades, historical trades, exit all positions. |
+| [**portfolio/**](portfolio/) | Positions, holdings, MTF positions, convert positions. |
+| [**market-quote/**](market-quote/) | LTP, full market quotes, OHLC (v2 & v3), option Greeks. |
+| [**historical-data/**](historical-data/) | Historical and intraday candle data (v2 & v3). |
+| [**option-chain/**](option-chain/) | Option contracts, put-call option chain. |
+| [**expired-instruments/**](expired-instruments/) | Expiries, expired future/option contracts, expired historical candle data. |
+| [**market-information/**](market-information/) | Exchange status, market timings, market holidays. |
+| [**gtt-orders/**](gtt-orders/) | Place, modify, cancel, and get details for GTT (Good Till Triggered) orders. |
+| [**margins/**](margins/) | Margin details. |
+| [**charges/**](charges/) | Brokerage details. |
+| [**trade-profit-and-loss/**](trade-profit-and-loss/) | P&amp;L report, report metadata, trade charges. |
+
+## Documentation
+
+- [Upstox API Documentation](https://upstox.com/developer/api-documentation)
+- [Upstox PHP SDK (Packagist)](https://packagist.org/packages/upstox/upstox-php-sdk)

--- a/examples/charges/README.md
+++ b/examples/charges/README.md
@@ -1,0 +1,10 @@
+# Charges – Example code
+
+Links to all charges-related examples in the `code/` folder.
+
+## 1. Brokerage Details
+
+- 1.1 [Get brokerage details for equity delivery orders](code/brokerage-details.md#get-brokerage-details-for-equity-delivery-orders)
+- 1.2 [Get brokerage details for equity intraday orders](code/brokerage-details.md#get-brokerage-details-for-equity-intraday-orders)
+- 1.3 [Get brokerage details for equity futures and options delivery orders](code/brokerage-details.md#get-brokerage-details-for-equity-futures-and-options-delivery-orders)
+- 1.4 [Get brokerage details for equity futures and options intraday orders](code/brokerage-details.md#get-brokerage-details-for-equity-futures-and-options-intraday-orders)

--- a/examples/charges/code/brokerage-details.md
+++ b/examples/charges/code/brokerage-details.md
@@ -1,0 +1,115 @@
+## Get brokerage details for equity delivery orders
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\ChargeApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$instrumentToken = 'NSE_EQ|INE669E01016';
+$quantity = 10;
+$product = 'D';
+$transactionType = 'BUY';
+$price = 13.4;
+
+try {
+    $result = $apiInstance->getBrokerage($instrumentToken, $quantity, $product, $transactionType, $price, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling ChargeApi->getBrokerage: ' . $e->getMessage();
+}
+```
+
+## Get brokerage details for equity intraday orders
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\ChargeApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$instrumentToken = 'NSE_EQ|INE669E01016';
+$quantity = 10;
+$product = 'I';
+$transactionType = 'BUY';
+$price = 13.4;
+
+try {
+    $result = $apiInstance->getBrokerage($instrumentToken, $quantity, $product, $transactionType, $price, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling ChargeApi->getBrokerage: ' . $e->getMessage();
+}
+```
+
+## Get brokerage details for equity futures and options delivery orders
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\ChargeApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$instrumentToken = 'NSE_FO|35271';
+$quantity = 10;
+$product = 'D';
+$transactionType = 'BUY';
+$price = 1333.4;
+
+try {
+    $result = $apiInstance->getBrokerage($instrumentToken, $quantity, $product, $transactionType, $price, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling ChargeApi->getBrokerage: ' . $e->getMessage();
+}
+```
+
+## Get brokerage details for equity futures and options intraday orders
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\ChargeApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$instrumentToken = 'NSE_FO|35271';
+$quantity = 10;
+$product = 'I';
+$transactionType = 'BUY';
+$price = 1333.4;
+
+try {
+    $result = $apiInstance->getBrokerage($instrumentToken, $quantity, $product, $transactionType, $price, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling ChargeApi->getBrokerage: ' . $e->getMessage();
+}
+```

--- a/examples/expired-instruments/README.md
+++ b/examples/expired-instruments/README.md
@@ -1,0 +1,19 @@
+# Expired Instruments – Example code
+
+Links to all expired-instruments-related examples in the `code/` folder.
+
+## 1. Get Expiries
+
+- 1.1 [Get Expiries for given instrument](code/get-expiries.md#get-expiries-for-given-instrument)
+
+## 2. Get Expired Option Contracts
+
+- 2.1 [Get Expired Option Contracts for given instrument with expiry date](code/get-expired-option-contracts.md#get-expired-option-contracts-for-given-instrument-with-expiry-date)
+
+## 3. Get Expired Future Contracts
+
+- 3.1 [Get Expired Future Contracts for given instrument with expiry date](code/get-expired-future-contracts.md#get-expired-future-contracts-for-given-instrument-with-expiry-date)
+
+## 4. Get Expired Historical Candle Data
+
+- 4.1 [Get Historical Candle Data for Expired Instruments](code/get-expired-historical-candle-data.md#get-historical-candle-data-for-expired-instruments)

--- a/examples/expired-instruments/code/get-expired-future-contracts.md
+++ b/examples/expired-instruments/code/get-expired-future-contracts.md
@@ -1,0 +1,22 @@
+## Get Expired Future Contracts for given instrument with expiry date
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\ExpiredInstrumentApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->getExpiredFutureContracts("NSE_INDEX|Nifty 50", "2024-11-27");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling ExpiredInstrumentApi->getExpiredFutureContracts: ' . $e->getMessage();
+}
+```

--- a/examples/expired-instruments/code/get-expired-historical-candle-data.md
+++ b/examples/expired-instruments/code/get-expired-historical-candle-data.md
@@ -1,0 +1,22 @@
+## Get Historical Candle Data for Expired Instruments
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\ExpiredInstrumentApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->getExpiredHistoricalCandleData("NSE_EQ|INE669E01016", "weeks", 1, "2025-11-25", "2002-11-25");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling ExpiredInstrumentApi->getExpiredHistoricalCandleData: ' . $e->getMessage();
+}
+```

--- a/examples/expired-instruments/code/get-expired-option-contracts.md
+++ b/examples/expired-instruments/code/get-expired-option-contracts.md
@@ -1,0 +1,22 @@
+## Get Expired Option Contracts for given instrument with expiry date
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\ExpiredInstrumentApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->getExpiredOptionContracts("NSE_INDEX|Nifty 50", "2025-04-30");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling ExpiredInstrumentApi->getExpiredOptionContracts: ' . $e->getMessage();
+}
+```

--- a/examples/expired-instruments/code/get-expiries.md
+++ b/examples/expired-instruments/code/get-expiries.md
@@ -1,0 +1,22 @@
+## Get Expiries for given instrument
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\ExpiredInstrumentApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->getExpiries("NSE_INDEX|Nifty 50");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling ExpiredInstrumentApi->getExpiries: ' . $e->getMessage();
+}
+```

--- a/examples/gtt-orders/README.md
+++ b/examples/gtt-orders/README.md
@@ -1,0 +1,21 @@
+# GTT Orders – Example code
+
+Links to all gtt-orders-related examples in the `code/` folder.
+
+## 1. Place GTT Order
+
+- 1.1 [Place Single Leg GTT Order](code/place-gtt-order.md#place-single-leg-gtt-order)
+- 1.2 [Place Multiple Leg GTT Order](code/place-gtt-order.md#place-multiple-leg-gtt-order)
+
+## 2. Modify GTT Order
+
+- 2.1 [Modify Single Leg GTT Order](code/modify-gtt-order.md#modify-single-leg-gtt-order)
+- 2.2 [Modify Multiple Leg GTT Order](code/modify-gtt-order.md#modify-multiple-leg-gtt-order)
+
+## 3. Cancel GTT Order
+
+- 3.1 [Cancel GTT Order](code/cancel-gtt-order.md#cancel-gtt-order)
+
+## 4. Get GTT Order Details
+
+- 4.1 [Get GTT Order Details](code/get-gtt-order-details.md#get-gtt-order-details)

--- a/examples/gtt-orders/code/cancel-gtt-order.md
+++ b/examples/gtt-orders/code/cancel-gtt-order.md
@@ -1,0 +1,25 @@
+## Cancel GTT Order
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApiV3(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$body = new \Upstox\Client\Model\GttCancelOrderRequest();
+$body->setGttOrderId("GTT-C250303008840");
+
+try {
+    $result = $apiInstance->cancelGTTOrder($body);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApiV3->cancelGTTOrder: ' . $e->getMessage();
+}
+```

--- a/examples/gtt-orders/code/get-gtt-order-details.md
+++ b/examples/gtt-orders/code/get-gtt-order-details.md
@@ -1,0 +1,22 @@
+## Get GTT Order Details
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApiV3(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->getGttOrderDetails("GTT-C25030300128840");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApiV3->getGttOrderDetails: ' . $e->getMessage();
+}
+```

--- a/examples/gtt-orders/code/modify-gtt-order.md
+++ b/examples/gtt-orders/code/modify-gtt-order.md
@@ -1,0 +1,77 @@
+## Modify Single Leg GTT Order
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApiV3(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$entryRule = new \Upstox\Client\Model\GttRule();
+$entryRule->setStrategy("ENTRY");
+$entryRule->setTriggerType("ABOVE");
+$entryRule->setTriggerPrice(7.3);
+
+$body = new \Upstox\Client\Model\GttModifyOrderRequest();
+$body->setType("SINGLE");
+$body->setGttOrderId("GTT-C25270200137952");
+$body->setRules([$entryRule]);
+$body->setQuantity(1);
+
+try {
+    $result = $apiInstance->modifyGTTOrder($body);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApiV3->modifyGTTOrder: ' . $e->getMessage();
+}
+```
+
+## Modify Multiple Leg GTT Order
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApiV3(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$entryRule = new \Upstox\Client\Model\GttRule();
+$entryRule->setStrategy("ENTRY");
+$entryRule->setTriggerType("ABOVE");
+$entryRule->setTriggerPrice(7.3);
+
+$targetRule = new \Upstox\Client\Model\GttRule();
+$targetRule->setStrategy("TARGET");
+$targetRule->setTriggerType("IMMEDIATE");
+$targetRule->setTriggerPrice(7.64);
+
+$stoplossRule = new \Upstox\Client\Model\GttRule();
+$stoplossRule->setStrategy("STOPLOSS");
+$stoplossRule->setTriggerType("IMMEDIATE");
+$stoplossRule->setTriggerPrice(7.1);
+
+$body = new \Upstox\Client\Model\GttModifyOrderRequest();
+$body->setType("MULTIPLE");
+$body->setGttOrderId("GTT-C25280200137522");
+$body->setRules([$entryRule, $targetRule, $stoplossRule]);
+$body->setQuantity(1);
+
+try {
+    $result = $apiInstance->modifyGTTOrder($body);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApiV3->modifyGTTOrder: ' . $e->getMessage();
+}
+```

--- a/examples/gtt-orders/code/place-gtt-order.md
+++ b/examples/gtt-orders/code/place-gtt-order.md
@@ -1,0 +1,81 @@
+## Place Single Leg GTT Order
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApiV3(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$entryRule = new \Upstox\Client\Model\GttRule();
+$entryRule->setStrategy("ENTRY");
+$entryRule->setTriggerType("ABOVE");
+$entryRule->setTriggerPrice(7.0);
+
+$body = new \Upstox\Client\Model\GttPlaceOrderRequest();
+$body->setType("SINGLE");
+$body->setInstrumentToken("NSE_EQ|INE669E01016");
+$body->setProduct("D");
+$body->setQuantity(1);
+$body->setRules([$entryRule]);
+$body->setTransactionType("BUY");
+
+try {
+    $result = $apiInstance->placeGTTOrder($body);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApiV3->placeGTTOrder: ' . $e->getMessage();
+}
+```
+
+## Place Multiple Leg GTT Order
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApiV3(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$entryRule = new \Upstox\Client\Model\GttRule();
+$entryRule->setStrategy("ENTRY");
+$entryRule->setTriggerType("ABOVE");
+$entryRule->setTriggerPrice(7.0);
+
+$targetRule = new \Upstox\Client\Model\GttRule();
+$targetRule->setStrategy("TARGET");
+$targetRule->setTriggerType("IMMEDIATE");
+$targetRule->setTriggerPrice(9.0);
+
+$stoplossRule = new \Upstox\Client\Model\GttRule();
+$stoplossRule->setStrategy("STOPLOSS");
+$stoplossRule->setTriggerType("IMMEDIATE");
+$stoplossRule->setTriggerPrice(5.0);
+
+$body = new \Upstox\Client\Model\GttPlaceOrderRequest();
+$body->setType("MULTIPLE");
+$body->setInstrumentToken("NSE_EQ|INE669E01016");
+$body->setProduct("D");
+$body->setQuantity(1);
+$body->setRules([$entryRule, $targetRule, $stoplossRule]);
+$body->setTransactionType("BUY");
+
+try {
+    $result = $apiInstance->placeGTTOrder($body);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApiV3->placeGTTOrder: ' . $e->getMessage();
+}
+```

--- a/examples/historical-data/README.md
+++ b/examples/historical-data/README.md
@@ -1,0 +1,43 @@
+# Historical Data – Example code
+
+Links to all historical-data-related examples in the `code/` folder.
+
+## 1. Historical Candle Data V3
+
+- 1.1 [Get data with a 1-minute interval](code/historical-candle-data-v3.md#get-data-with-a-1-minute-interval)
+- 1.2 [Get data with a 3-minute interval](code/historical-candle-data-v3.md#get-data-with-a-3-minute-interval)
+- 1.3 [Get data with a 15-minute interval](code/historical-candle-data-v3.md#get-data-with-a-15-minute-interval)
+- 1.4 [Get data with a 1-hour interval](code/historical-candle-data-v3.md#get-data-with-a-1-hour-interval)
+- 1.5 [Get data with a 4-hour interval](code/historical-candle-data-v3.md#get-data-with-a-4-hour-interval)
+- 1.6 [Get data with a daily interval](code/historical-candle-data-v3.md#get-data-with-a-daily-interval)
+- 1.7 [Get data with a weekly interval](code/historical-candle-data-v3.md#get-data-with-a-weekly-interval)
+- 1.8 [Get data with a monthly interval](code/historical-candle-data-v3.md#get-data-with-a-monthly-interval)
+
+## 2. Intraday Candle Data V3
+
+- 2.1 [Get data with a 1-minute interval](code/intra-day-candle-data-v3.md#get-data-with-a-1-minute-interval)
+- 2.2 [Get data with a 3-minute interval](code/intra-day-candle-data-v3.md#get-data-with-a-3-minute-interval)
+- 2.3 [Get data with a 5-minute interval](code/intra-day-candle-data-v3.md#get-data-with-a-5-minute-interval)
+- 2.4 [Get data with a 15-minute interval](code/intra-day-candle-data-v3.md#get-data-with-a-15-minute-interval)
+- 2.5 [Get data with a 30-minute interval](code/intra-day-candle-data-v3.md#get-data-with-a-30-minute-interval)
+- 2.6 [Get data with a 1-hour interval](code/intra-day-candle-data-v3.md#get-data-with-a-1-hour-interval)
+- 2.7 [Get data with a 2-hour interval](code/intra-day-candle-data-v3.md#get-data-with-a-2-hour-interval)
+- 2.8 [Get current day data](code/intra-day-candle-data-v3.md#get-current-day-data)
+
+## 3. Historical Candle Data
+
+- 3.1 [Get historical candle data with a 1-minute interval](code/historical-candle-data.md#get-historical-candle-data-with-a-1-minute-interval)
+- 3.2 [Get data with a 30-minute interval](code/historical-candle-data.md#get-data-with-a-30-minute-interval)
+- 3.3 [Get data with a daily interval](code/historical-candle-data.md#get-data-with-a-daily-interval)
+- 3.4 [Get data with a weekly interval](code/historical-candle-data.md#get-data-with-a-weekly-interval)
+- 3.5 [Get data with a monthly interval](code/historical-candle-data.md#get-data-with-a-monthly-interval)
+- 3.6 [Get historical candle data with a 1-minute interval](code/historical-candle-data.md#get-historical-candle-data-with-a-1-minute-interval-1)
+- 3.7 [Get data with a 30-minute interval](code/historical-candle-data.md#get-data-with-a-30-minute-interval-1)
+- 3.8 [Get data with a daily interval](code/historical-candle-data.md#get-data-with-a-daily-interval-1)
+- 3.9 [Get data with a weekly interval](code/historical-candle-data.md#get-data-with-a-weekly-interval-1)
+- 3.10 [Get data with a monthly interval](code/historical-candle-data.md#get-data-with-a-monthly-interval-1)
+
+## 4. Intraday Candle Data
+
+- 4.1 [Get intraday candle data with a 1-minute interval](code/intra-day-candle-data.md#get-intraday-candle-data-with-a-1-minute-interval)
+- 4.2 [Get intraday candle data with a 30-minute interval](code/intra-day-candle-data.md#get-intraday-candle-data-with-a-30-minute-interval)

--- a/examples/historical-data/code/historical-candle-data-v3.md
+++ b/examples/historical-data/code/historical-candle-data-v3.md
@@ -1,0 +1,143 @@
+## Get data with a 1-minute interval
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryV3Api(
+    new GuzzleHttp\Client()
+);
+
+try {
+    $result = $apiInstance->getHistoricalCandleData1("NSE_EQ|INE848E01016", "minutes", 1, "2025-01-02", "2025-01-01");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryV3Api->getHistoricalCandleData1: ' . $e->getMessage();
+}
+```
+
+## Get data with a 3-minute interval
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryV3Api(
+    new GuzzleHttp\Client()
+);
+
+try {
+    $result = $apiInstance->getHistoricalCandleData1("NSE_EQ|INE848E01016", "minutes", 3, "2025-01-02", "2025-01-01");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryV3Api->getHistoricalCandleData1: ' . $e->getMessage();
+}
+```
+
+## Get data with a 15-minute interval
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryV3Api(
+    new GuzzleHttp\Client()
+);
+
+try {
+    $result = $apiInstance->getHistoricalCandleData1("NSE_EQ|INE848E01016", "minutes", 15, "2025-01-04", "2025-01-01");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryV3Api->getHistoricalCandleData1: ' . $e->getMessage();
+}
+```
+
+## Get data with a 1-hour interval
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryV3Api(
+    new GuzzleHttp\Client()
+);
+
+try {
+    $result = $apiInstance->getHistoricalCandleData1("NSE_EQ|INE848E01016", "hours", 1, "2025-02-01", "2025-01-01");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryV3Api->getHistoricalCandleData1: ' . $e->getMessage();
+}
+```
+
+## Get data with a 4-hour interval
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryV3Api(
+    new GuzzleHttp\Client()
+);
+
+try {
+    $result = $apiInstance->getHistoricalCandleData1("NSE_EQ|INE848E01016", "hours", 4, "2025-02-01", "2025-01-01");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryV3Api->getHistoricalCandleData1: ' . $e->getMessage();
+}
+```
+
+## Get data with a daily interval
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryV3Api(
+    new GuzzleHttp\Client()
+);
+
+try {
+    $result = $apiInstance->getHistoricalCandleData1("NSE_EQ|INE848E01016", "days", 1, "2025-03-01", "2025-01-01");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryV3Api->getHistoricalCandleData1: ' . $e->getMessage();
+}
+```
+
+## Get data with a weekly interval
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryV3Api(
+    new GuzzleHttp\Client()
+);
+
+try {
+    $result = $apiInstance->getHistoricalCandleData1("NSE_EQ|INE848E01016", "weeks", 1, "2025-01-01", "2024-01-01");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryV3Api->getHistoricalCandleData1: ' . $e->getMessage();
+}
+```
+
+## Get data with a monthly interval
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryV3Api(
+    new GuzzleHttp\Client()
+);
+
+try {
+    $result = $apiInstance->getHistoricalCandleData1("NSE_EQ|INE848E01016", "months", 1, "2025-01-01", "2010-01-01");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryV3Api->getHistoricalCandleData1: ' . $e->getMessage();
+}
+```

--- a/examples/historical-data/code/historical-candle-data.md
+++ b/examples/historical-data/code/historical-candle-data.md
@@ -1,0 +1,224 @@
+## Get historical candle data with a 1-minute interval
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryApi(
+    new GuzzleHttp\Client()
+);
+
+$instrumentKey = 'NSE_EQ|INE669E01016';
+$interval = '1minute';
+$toDate = '2023-11-13';
+$fromDate = '2023-11-12';
+
+try {
+    $result = $apiInstance->getHistoricalCandleData1($instrumentKey, $interval, $toDate, $fromDate, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryApi->getHistoricalCandleData1: ' . $e->getMessage();
+}
+```
+
+## Get data with a 30-minute interval
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryApi(
+    new GuzzleHttp\Client()
+);
+
+$instrumentKey = 'NSE_EQ|INE669E01016';
+$interval = '30minute';
+$toDate = '2023-11-13';
+$fromDate = '2023-11-12';
+
+try {
+    $result = $apiInstance->getHistoricalCandleData1($instrumentKey, $interval, $toDate, $fromDate, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryApi->getHistoricalCandleData1: ' . $e->getMessage();
+}
+```
+
+## Get data with a daily interval
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryApi(
+    new GuzzleHttp\Client()
+);
+
+$instrumentKey = 'NSE_EQ|INE669E01016';
+$interval = 'day';
+$toDate = '2023-11-13';
+$fromDate = '2023-11-12';
+
+try {
+    $result = $apiInstance->getHistoricalCandleData1($instrumentKey, $interval, $toDate, $fromDate, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryApi->getHistoricalCandleData1: ' . $e->getMessage();
+}
+```
+
+## Get data with a weekly interval
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryApi(
+    new GuzzleHttp\Client()
+);
+
+$instrumentKey = 'NSE_EQ|INE669E01016';
+$interval = 'week';
+$toDate = '2023-11-13';
+$fromDate = '2023-10-13';
+
+try {
+    $result = $apiInstance->getHistoricalCandleData1($instrumentKey, $interval, $toDate, $fromDate, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryApi->getHistoricalCandleData1: ' . $e->getMessage();
+}
+```
+
+## Get data with a monthly interval
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryApi(
+    new GuzzleHttp\Client()
+);
+
+$instrumentKey = 'NSE_EQ|INE669E01016';
+$interval = 'month';
+$toDate = '2023-11-13';
+$fromDate = '2022-10-13';
+
+try {
+    $result = $apiInstance->getHistoricalCandleData1($instrumentKey, $interval, $toDate, $fromDate, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryApi->getHistoricalCandleData1: ' . $e->getMessage();
+}
+```
+
+## Get historical candle data with a 1-minute interval
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryApi(
+    new GuzzleHttp\Client()
+);
+
+$instrumentKey = 'NSE_EQ|INE669E01016';
+$interval = '1minute';
+$toDate = '2023-11-13';
+
+try {
+    $result = $apiInstance->getHistoricalCandleData($instrumentKey, $interval, $toDate, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryApi->getHistoricalCandleData: ' . $e->getMessage();
+}
+```
+
+## Get data with a 30-minute interval
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryApi(
+    new GuzzleHttp\Client()
+);
+
+$instrumentKey = 'NSE_EQ|INE669E01016';
+$interval = '30minute';
+$toDate = '2023-11-13';
+
+try {
+    $result = $apiInstance->getHistoricalCandleData($instrumentKey, $interval, $toDate, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryApi->getHistoricalCandleData: ' . $e->getMessage();
+}
+```
+
+## Get data with a daily interval
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryApi(
+    new GuzzleHttp\Client()
+);
+
+$instrumentKey = 'NSE_EQ|INE669E01016';
+$interval = 'day';
+$toDate = '2023-11-13';
+
+try {
+    $result = $apiInstance->getHistoricalCandleData($instrumentKey, $interval, $toDate, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryApi->getHistoricalCandleData: ' . $e->getMessage();
+}
+```
+
+## Get data with a weekly interval
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryApi(
+    new GuzzleHttp\Client()
+);
+
+$instrumentKey = 'NSE_EQ|INE669E01016';
+$interval = 'week';
+$toDate = '2023-11-13';
+
+try {
+    $result = $apiInstance->getHistoricalCandleData($instrumentKey, $interval, $toDate, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryApi->getHistoricalCandleData: ' . $e->getMessage();
+}
+```
+
+## Get data with a monthly interval
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryApi(
+    new GuzzleHttp\Client()
+);
+
+$instrumentKey = 'NSE_EQ|INE669E01016';
+$interval = 'month';
+$toDate = '2023-11-13';
+
+try {
+    $result = $apiInstance->getHistoricalCandleData($instrumentKey, $interval, $toDate, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryApi->getHistoricalCandleData: ' . $e->getMessage();
+}
+```

--- a/examples/historical-data/code/intra-day-candle-data-v3.md
+++ b/examples/historical-data/code/intra-day-candle-data-v3.md
@@ -1,0 +1,143 @@
+## Get data with a 1-minute interval
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryV3Api(
+    new GuzzleHttp\Client()
+);
+
+try {
+    $result = $apiInstance->getIntraDayCandleData("NSE_EQ|INE848E01016", "minutes", 1);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryV3Api->getIntraDayCandleData: ' . $e->getMessage();
+}
+```
+
+## Get data with a 3-minute interval
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryV3Api(
+    new GuzzleHttp\Client()
+);
+
+try {
+    $result = $apiInstance->getIntraDayCandleData("NSE_EQ|INE848E01016", "minutes", 3);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryV3Api->getIntraDayCandleData: ' . $e->getMessage();
+}
+```
+
+## Get data with a 5-minute interval
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryV3Api(
+    new GuzzleHttp\Client()
+);
+
+try {
+    $result = $apiInstance->getIntraDayCandleData("NSE_EQ|INE848E01016", "minutes", 5);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryV3Api->getIntraDayCandleData: ' . $e->getMessage();
+}
+```
+
+## Get data with a 15-minute interval
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryV3Api(
+    new GuzzleHttp\Client()
+);
+
+try {
+    $result = $apiInstance->getIntraDayCandleData("NSE_EQ|INE848E01016", "minutes", 15);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryV3Api->getIntraDayCandleData: ' . $e->getMessage();
+}
+```
+
+## Get data with a 30-minute interval
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryV3Api(
+    new GuzzleHttp\Client()
+);
+
+try {
+    $result = $apiInstance->getIntraDayCandleData("NSE_EQ|INE848E01016", "minutes", 30);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryV3Api->getIntraDayCandleData: ' . $e->getMessage();
+}
+```
+
+## Get data with a 1-hour interval
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryV3Api(
+    new GuzzleHttp\Client()
+);
+
+try {
+    $result = $apiInstance->getIntraDayCandleData("NSE_EQ|INE848E01016", "hours", 1);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryV3Api->getIntraDayCandleData: ' . $e->getMessage();
+}
+```
+
+## Get data with a 2-hour interval
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryV3Api(
+    new GuzzleHttp\Client()
+);
+
+try {
+    $result = $apiInstance->getIntraDayCandleData("NSE_EQ|INE848E01016", "hours", 2);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryV3Api->getIntraDayCandleData: ' . $e->getMessage();
+}
+```
+
+## Get current day data
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryV3Api(
+    new GuzzleHttp\Client()
+);
+
+try {
+    $result = $apiInstance->getIntraDayCandleData("NSE_EQ|INE848E01016", "days", 1);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryV3Api->getIntraDayCandleData: ' . $e->getMessage();
+}
+```

--- a/examples/historical-data/code/intra-day-candle-data.md
+++ b/examples/historical-data/code/intra-day-candle-data.md
@@ -1,0 +1,41 @@
+## Get intraday candle data with a 1-minute interval
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryApi(
+    new GuzzleHttp\Client()
+);
+
+$instrumentKey = 'NSE_EQ|INE669E01016';
+$interval = '1minute';
+
+try {
+    $result = $apiInstance->getIntraDayCandleData($instrumentKey, $interval, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryApi->getIntraDayCandleData: ' . $e->getMessage();
+}
+```
+
+## Get intraday candle data with a 30-minute interval
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\HistoryApi(
+    new GuzzleHttp\Client()
+);
+
+$instrumentKey = 'NSE_EQ|INE669E01016';
+$interval = '30minute';
+
+try {
+    $result = $apiInstance->getIntraDayCandleData($instrumentKey, $interval, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling HistoryApi->getIntraDayCandleData: ' . $e->getMessage();
+}
+```

--- a/examples/login/README.md
+++ b/examples/login/README.md
@@ -1,0 +1,15 @@
+# Login – Example code
+
+Links to all login-related examples in the `code/` folder.
+
+## 1. Get Token
+
+- 1.1 [Get access token using auth code](code/get-token.md#get-access-token-using-auth-code)
+
+## 2. Access Token Request
+
+- 2.1 [Access token request](code/access-token-request.md#access-token-request)
+
+## 3. Logout
+
+- 3.1 [Example](code/logout.md#example)

--- a/examples/login/code/access-token-request.md
+++ b/examples/login/code/access-token-request.md
@@ -1,0 +1,20 @@
+## Access token request
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\LoginApi(
+    new GuzzleHttp\Client()
+);
+
+$body = new \Upstox\Client\Model\IndieUserTokenRequest();
+$body->setClientSecret("****");
+
+try {
+    $result = $apiInstance->initTokenRequestForIndieUser($body, "*****");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling indie token request: ' . $e->getMessage();
+}
+```

--- a/examples/login/code/get-token.md
+++ b/examples/login/code/get-token.md
@@ -1,0 +1,24 @@
+## Get access token using auth code
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\LoginApi(
+    new GuzzleHttp\Client()
+);
+
+$apiVersion = '2.0';
+$code = '{your_auth_code}';
+$clientId = '{your_client_id}';
+$clientSecret = '{your_client_secret}';
+$redirectUri = '{your_redirect_url}';
+$grantType = 'authorization_code';
+
+try {
+    $result = $apiInstance->token($apiVersion, $code, $clientId, $clientSecret, $redirectUri, $grantType);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling LoginApi->token: ' . $e->getMessage();
+}
+```

--- a/examples/login/code/logout.md
+++ b/examples/login/code/logout.md
@@ -1,0 +1,22 @@
+## Example
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\LoginApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->logout('2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling LoginApi->logout: ' . $e->getMessage();
+}
+```

--- a/examples/margins/README.md
+++ b/examples/margins/README.md
@@ -1,0 +1,11 @@
+# Margins – Example code
+
+Links to all margins-related examples in the `code/` folder.
+
+## 1. Margin Details
+
+- 1.1 [Get margin details for equity delivery orders](code/margin-details.md#get-margin-details-for-equity-delivery-orders)
+- 1.2 [Get margin details for future delivery orders](code/margin-details.md#get-margin-details-for-future-delivery-orders)
+- 1.3 [Get margin details for option delivery orders](code/margin-details.md#get-margin-details-for-option-delivery-orders)
+- 1.4 [Get margin details for MCX delivery orders](code/margin-details.md#get-margin-details-for-mcx-delivery-orders)
+- 1.5 [Get margin details for currency delivery orders](code/margin-details.md#get-margin-details-for-currency-delivery-orders)

--- a/examples/margins/code/margin-details.md
+++ b/examples/margins/code/margin-details.md
@@ -1,0 +1,159 @@
+## Get margin details for equity delivery orders
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\ChargeApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$instrument = new \Upstox\Client\Model\Instrument();
+$instrument->setInstrumentKey("NSE_EQ|INE528G01035");
+$instrument->setQuantity(5);
+$instrument->setProduct("D");
+$instrument->setTransactionType("BUY");
+
+$marginBody = new \Upstox\Client\Model\MarginRequest();
+$marginBody->setInstruments([$instrument]);
+
+try {
+    $result = $apiInstance->postMargin($marginBody);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling ChargeApi->postMargin: ' . $e->getMessage();
+}
+```
+
+## Get margin details for future delivery orders
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\ChargeApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$instrument = new \Upstox\Client\Model\Instrument();
+$instrument->setInstrumentKey("NSE_FO|35000");
+$instrument->setQuantity(5);
+$instrument->setProduct("D");
+$instrument->setTransactionType("BUY");
+
+$marginBody = new \Upstox\Client\Model\MarginRequest();
+$marginBody->setInstruments([$instrument]);
+
+try {
+    $result = $apiInstance->postMargin($marginBody);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling ChargeApi->postMargin: ' . $e->getMessage();
+}
+```
+
+## Get margin details for option delivery orders
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\ChargeApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$instrument = new \Upstox\Client\Model\Instrument();
+$instrument->setInstrumentKey("NSE_FO|54524");
+$instrument->setQuantity(5);
+$instrument->setProduct("D");
+$instrument->setTransactionType("BUY");
+
+$marginBody = new \Upstox\Client\Model\MarginRequest();
+$marginBody->setInstruments([$instrument]);
+
+try {
+    $result = $apiInstance->postMargin($marginBody);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling ChargeApi->postMargin: ' . $e->getMessage();
+}
+```
+
+## Get margin details for MCX delivery orders
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\ChargeApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$instrument = new \Upstox\Client\Model\Instrument();
+$instrument->setInstrumentKey("MCX_FO|435356");
+$instrument->setQuantity(5);
+$instrument->setProduct("D");
+$instrument->setTransactionType("BUY");
+
+$marginBody = new \Upstox\Client\Model\MarginRequest();
+$marginBody->setInstruments([$instrument]);
+
+try {
+    $result = $apiInstance->postMargin($marginBody);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling ChargeApi->postMargin: ' . $e->getMessage();
+}
+```
+
+## Get margin details for currency delivery orders
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\ChargeApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$instrument = new \Upstox\Client\Model\Instrument();
+$instrument->setInstrumentKey("NCD_FO|15758");
+$instrument->setQuantity(5);
+$instrument->setProduct("D");
+$instrument->setTransactionType("BUY");
+
+$marginBody = new \Upstox\Client\Model\MarginRequest();
+$marginBody->setInstruments([$instrument]);
+
+try {
+    $result = $apiInstance->postMargin($marginBody);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling ChargeApi->postMargin: ' . $e->getMessage();
+}
+```

--- a/examples/market-information/README.md
+++ b/examples/market-information/README.md
@@ -1,0 +1,16 @@
+# Market Information – Example code
+
+Links to all market-information-related examples in the `code/` folder.
+
+## 1. Market Holidays
+
+- 1.1 [Get market holidays for current year](code/market-holidays.md#get-market-holidays-for-current-year)
+- 1.2 [Get market holiday status of a date](code/market-holidays.md#get-market-holiday-status-of-a-date)
+
+## 2. Market Timings
+
+- 2.1 [Get market timings of a date](code/market-timings.md#get-market-timings-of-a-date)
+
+## 3. Exchange Status
+
+- 3.1 [Get market status for a particular exchange](code/exchange-status.md#get-market-status-for-a-particular-exchange)

--- a/examples/market-information/code/exchange-status.md
+++ b/examples/market-information/code/exchange-status.md
@@ -1,0 +1,22 @@
+## Get market status for a particular exchange
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\MarketHolidaysAndTimingsApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->getMarketStatus("NSE");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling MarketHolidaysAndTimingsApi->getMarketStatus: ' . $e->getMessage();
+}
+```

--- a/examples/market-information/code/market-holidays.md
+++ b/examples/market-information/code/market-holidays.md
@@ -1,0 +1,35 @@
+## Get market holidays for current year
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\MarketHolidaysAndTimingsApi(
+    new GuzzleHttp\Client()
+);
+
+try {
+    $result = $apiInstance->getHolidays();
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling MarketHolidaysAndTimingsApi->getHolidays: ' . $e->getMessage();
+}
+```
+
+## Get market holiday status of a date
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\MarketHolidaysAndTimingsApi(
+    new GuzzleHttp\Client()
+);
+
+try {
+    $result = $apiInstance->getHoliday("2024-01-22");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling MarketHolidaysAndTimingsApi->getHoliday: ' . $e->getMessage();
+}
+```

--- a/examples/market-information/code/market-timings.md
+++ b/examples/market-information/code/market-timings.md
@@ -1,0 +1,17 @@
+## Get market timings of a date
+
+
+```php
+<?php
+
+$apiInstance = new Upstox\Client\Api\MarketHolidaysAndTimingsApi(
+    new GuzzleHttp\Client()
+);
+
+try {
+    $result = $apiInstance->getExchangeTimings("2024-01-22");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling MarketHolidaysAndTimingsApi->getExchangeTimings: ' . $e->getMessage();
+}
+```

--- a/examples/market-quote/README.md
+++ b/examples/market-quote/README.md
@@ -1,0 +1,33 @@
+# Market Quote – Example code
+
+Links to all market-quote-related examples in the `code/` folder.
+
+## 1. Full Market Quotes
+
+- 1.1 [Get full market quote](code/full-market-quotes.md#get-full-market-quote)
+- 1.2 [Get full market quote for multiple instrument keys](code/full-market-quotes.md#get-full-market-quote-for-multiple-instrument-keys)
+
+## 2. OHLC Quotes V3
+
+- 2.1 [Get ohlc (open, high, low, close) market quotes](code/ohlc-quotes-v3.md#get-ohlc-open-high-low-close-market-quotes)
+- 2.2 [Get ohlc (open, high, low, close) market quotes for multiple instrument keys](code/ohlc-quotes-v3.md#get-ohlc-open-high-low-close-market-quotes-for-multiple-instrument-keys)
+
+## 3. LTP Quotes V3
+
+- 3.1 [Get ltp (last traded price) market quotes](code/ltp-quotes-v3.md#get-ltp-last-traded-price-market-quotes)
+- 3.2 [Get ltp (last traded price) market quotes for multiple instruments keys](code/ltp-quotes-v3.md#get-ltp-last-traded-price-market-quotes-for-multiple-instruments-keys)
+
+## 4. Option Greek
+
+- 4.1 [Get Option Greek fields](code/option-greek.md#get-option-greek-fields)
+- 4.2 [Get Option Greek fields for multiple instruments keys](code/option-greek.md#get-option-greek-fields-for-multiple-instruments-keys)
+
+## 5. OHLC Quotes
+
+- 5.1 [Get ohlc (open, high, low, close) market quotes](code/ohlc-quotes.md#get-ohlc-open-high-low-close-market-quotes)
+- 5.2 [Get ohlc (open, high, low, close) market quotes for multiple instrument keys](code/ohlc-quotes.md#get-ohlc-open-high-low-close-market-quotes-for-multiple-instrument-keys)
+
+## 6. LTP Quotes
+
+- 6.1 [Get ltp (last traded price) market quotes](code/ltp-quotes.md#get-ltp-last-traded-price-market-quotes)
+- 6.2 [Get ltp (last traded price) market quotes for multiple instruments keys](code/ltp-quotes.md#get-ltp-last-traded-price-market-quotes-for-multiple-instruments-keys)

--- a/examples/market-quote/code/full-market-quotes.md
+++ b/examples/market-quote/code/full-market-quotes.md
@@ -1,0 +1,49 @@
+## Get full market quote
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\MarketQuoteApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$symbol = 'NSE_EQ|INE669E01016';
+
+try {
+    $result = $apiInstance->getFullMarketQuote($symbol, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling MarketQuoteApi->getFullMarketQuote: ' . $e->getMessage();
+}
+```
+
+## Get full market quote for multiple instrument keys
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\MarketQuoteApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$symbol = 'NSE_EQ|INE669E01016,NSE_EQ|INE848E01016';
+
+try {
+    $result = $apiInstance->getFullMarketQuote($symbol, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling MarketQuoteApi->getFullMarketQuote: ' . $e->getMessage();
+}
+```

--- a/examples/market-quote/code/ltp-quotes-v3.md
+++ b/examples/market-quote/code/ltp-quotes-v3.md
@@ -1,0 +1,45 @@
+## Get ltp (last traded price) market quotes
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\MarketQuoteV3Api(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->getLtp("NSE_EQ|INE848E01016");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling MarketQuoteV3Api->getLtp: ' . $e->getMessage();
+}
+```
+
+## Get ltp (last traded price) market quotes for multiple instruments keys
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\MarketQuoteV3Api(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->getLtp("NSE_EQ|INE848E01016,NSE_EQ|INE669E01016");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling MarketQuoteV3Api->getLtp: ' . $e->getMessage();
+}
+```

--- a/examples/market-quote/code/ltp-quotes.md
+++ b/examples/market-quote/code/ltp-quotes.md
@@ -1,0 +1,49 @@
+## Get ltp (last traded price) market quotes
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\MarketQuoteApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$symbol = 'NSE_EQ|INE669E01016';
+
+try {
+    $result = $apiInstance->ltp($symbol, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling MarketQuoteApi->ltp: ' . $e->getMessage();
+}
+```
+
+## Get ltp (last traded price) market quotes for multiple instruments keys
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\MarketQuoteApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$symbol = 'NSE_EQ|INE669E01016,NSE_EQ|INE848E01016';
+
+try {
+    $result = $apiInstance->ltp($symbol, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling MarketQuoteApi->ltp: ' . $e->getMessage();
+}
+```

--- a/examples/market-quote/code/ohlc-quotes-v3.md
+++ b/examples/market-quote/code/ohlc-quotes-v3.md
@@ -1,0 +1,45 @@
+## Get ohlc (open, high, low, close) market quotes
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\MarketQuoteV3Api(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->getMarketQuoteOHLC("1d", "NSE_EQ|INE669E01016");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling MarketQuoteV3Api->getMarketQuoteOHLC: ' . $e->getMessage();
+}
+```
+
+## Get ohlc (open, high, low, close) market quotes for multiple instrument keys
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\MarketQuoteV3Api(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->getMarketQuoteOHLC("1d", "NSE_EQ|INE669E01016,NSE_EQ|INE848E01016");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling MarketQuoteV3Api->getMarketQuoteOHLC: ' . $e->getMessage();
+}
+```

--- a/examples/market-quote/code/ohlc-quotes.md
+++ b/examples/market-quote/code/ohlc-quotes.md
@@ -1,0 +1,51 @@
+## Get ohlc (open, high, low, close) market quotes
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\MarketQuoteApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$symbol = 'NSE_EQ|INE669E01016';
+$interval = '1d';
+
+try {
+    $result = $apiInstance->getMarketQuoteOhlc($symbol, $interval, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling MarketQuoteApi->getMarketQuoteOhlc: ' . $e->getMessage();
+}
+```
+
+## Get ohlc (open, high, low, close) market quotes for multiple instrument keys
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\MarketQuoteApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$symbol = 'NSE_EQ|INE669E01016,NSE_EQ|INE848E01016';
+$interval = '1d';
+
+try {
+    $result = $apiInstance->getMarketQuoteOhlc($symbol, $interval, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling MarketQuoteApi->getMarketQuoteOhlc: ' . $e->getMessage();
+}
+```

--- a/examples/market-quote/code/option-greek.md
+++ b/examples/market-quote/code/option-greek.md
@@ -1,0 +1,45 @@
+## Get Option Greek fields
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\MarketQuoteV3Api(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->getMarketQuoteOptionGreek("NSE_FO|43885");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling MarketQuoteV3Api->getMarketQuoteOptionGreek: ' . $e->getMessage();
+}
+```
+
+## Get Option Greek fields for multiple instruments keys
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\MarketQuoteV3Api(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->getMarketQuoteOptionGreek("NSE_FO|38604,NSE_FO|49210");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling MarketQuoteV3Api->getMarketQuoteOptionGreek: ' . $e->getMessage();
+}
+```

--- a/examples/option-chain/README.md
+++ b/examples/option-chain/README.md
@@ -1,0 +1,12 @@
+# Option Chain – Example code
+
+Links to all option-chain-related examples in the `code/` folder.
+
+## 1. Option Contracts
+
+- 1.1 [Get option contracts of an instrument key](code/option-contracts.md#get-option-contracts-of-an-instrument-key)
+- 1.2 [Get option contracts of an instrument key with expiry date](code/option-contracts.md#get-option-contracts-of-an-instrument-key-with-expiry-date)
+
+## 2. Put Call Option Chain
+
+- 2.1 [Get put/call option chain](code/put-call-option-chain.md#get-putcall-option-chain)

--- a/examples/option-chain/code/option-contracts.md
+++ b/examples/option-chain/code/option-contracts.md
@@ -1,0 +1,45 @@
+## Get option contracts of an instrument key
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OptionsApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->getOptionContracts("NSE_INDEX|Nifty 50");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OptionsApi->getOptionContracts: ' . $e->getMessage();
+}
+```
+
+## Get option contracts of an instrument key with expiry date
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OptionsApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->getOptionContracts("NSE_INDEX|Nifty 50", "2024-10-31");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OptionsApi->getOptionContracts: ' . $e->getMessage();
+}
+```

--- a/examples/option-chain/code/put-call-option-chain.md
+++ b/examples/option-chain/code/put-call-option-chain.md
@@ -1,0 +1,22 @@
+## Get put/call option chain
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OptionsApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->getPutCallOptionChain("NSE_INDEX|Nifty 50", "2024-10-31");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OptionsApi->getPutCallOptionChain: ' . $e->getMessage();
+}
+```

--- a/examples/orders/README.md
+++ b/examples/orders/README.md
@@ -1,0 +1,79 @@
+# Orders – Example code
+
+Links to all order-related examples in the `code/` folder.
+
+## 1. Place Order V3
+
+- 1.1 [Place an order with slicing enabled](code/place-order-v3.md#place-an-order-with-slicing-enabled)
+- 1.2 [Place an order with slicing disabled](code/place-order-v3.md#place-an-order-with-slicing-disabled)
+
+## 2. Place Multi Order
+
+- 2.1 [Place a multi order](code/place-multi-order.md#place-a-multi-order)
+- 2.2 [Place Multiple BUY and SELL Orders](code/place-multi-order.md#place-multiple-buy-and-sell-orders)
+- 2.3 [Place Multiple Orders with Auto Slicing enabled](code/place-multi-order.md#place-multiple-orders-with-auto-slicing-enabled)
+
+## 3. Modify Order V3
+
+- 3.1 [Modify a delivery order](code/modify-order-v3.md#modify-a-delivery-order)
+
+## 4. Cancel Order V3
+
+- 4.1 [Cancel an open order](code/cancel-order-v3.md#cancel-an-open-order)
+
+## 5. Cancel Multi Order
+
+- 5.1 [Cancel all the open orders](code/cancel-multi-order.md#cancel-all-the-open-orders)
+- 5.2 [Cancel all the open orders for a given segment](code/cancel-multi-order.md#cancel-all-the-open-orders-for-a-given-segment)
+- 5.3 [Cancel all the open orders for a given tag](code/cancel-multi-order.md#cancel-all-the-open-orders-for-a-given-tag)
+
+## 6. Exit All Positions
+
+- 6.1 [Exit all the open positions](code/exit-all-positions.md#exit-all-the-open-positions)
+- 6.2 [Exit all the open positions for a given segment](code/exit-all-positions.md#exit-all-the-open-positions-for-a-given-segment)
+- 6.3 [Exit all the open positions for a given tag](code/exit-all-positions.md#exit-all-the-open-positions-for-a-given-tag)
+
+## 7. Get Order Details
+
+- 7.1 [Get order details for an order number](code/get-order-details.md#get-order-details-for-an-order-number)
+
+## 8. Get Order History
+
+- 8.1 [Get order history for an order number](code/get-order-history.md#get-order-history-for-an-order-number)
+
+## 9. Get Order Book
+
+- 9.1 [Get all orders for the day](code/get-order-book.md#get-all-orders-for-the-day)
+
+## 10. Get Trades
+
+- 10.1 [Get all trades for the day](code/get-trades.md#get-all-trades-for-the-day)
+
+## 11. Get Trades for Order
+
+- 11.1 [Get trades for an order number](code/get-order-trades.md#get-trades-for-an-order-number)
+
+## 12. Get Trade History
+
+- 12.1 [Get trade history for equity segment](code/get-historical-trades.md#get-trade-history-for-equity-segment)
+- 12.2 [Get trade history for futures and options segment](code/get-historical-trades.md#get-trade-history-for-futures-and-options-segment)
+
+## 13. Place Order
+
+- 13.1 [Place a delivery market order](code/place-order.md#place-a-delivery-market-order)
+- 13.2 [Place a delivery limit order](code/place-order.md#place-a-delivery-limit-order)
+- 13.3 [Place a delivery stop-loss order](code/place-order.md#place-a-delivery-stop-loss-order)
+- 13.4 [Place a delivery stop-loss order market](code/place-order.md#place-a-delivery-stop-loss-order-market)
+- 13.5 [Place an intraday market order](code/place-order.md#place-an-intraday-market-order)
+- 13.6 [Place an intraday limit order](code/place-order.md#place-an-intraday-limit-order)
+- 13.7 [Place an intraday stop-loss order](code/place-order.md#place-an-intraday-stop-loss-order)
+- 13.8 [Place an intraday stop-loss market order](code/place-order.md#place-an-intraday-stop-loss-market-order)
+- 13.9 [Place a delivery market amo (after market order)](code/place-order.md#place-a-delivery-market-amo-after-market-order)
+
+## 14. Modify Order
+
+- 14.1 [Modify a delivery order](code/modify-order.md#modify-a-delivery-order)
+
+## 15. Cancel Order
+
+- 15.1 [Cancel an open order](code/cancel-order.md#cancel-an-open-order)

--- a/examples/orders/code/cancel-multi-order.md
+++ b/examples/orders/code/cancel-multi-order.md
@@ -1,0 +1,68 @@
+## Cancel all the open orders
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->cancelMultiOrder();
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApi->cancelMultiOrder: ' . $e->getMessage();
+}
+```
+
+## Cancel all the open orders for a given segment
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->cancelMultiOrder(null, "NSE_FO");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApi->cancelMultiOrder: ' . $e->getMessage();
+}
+```
+
+## Cancel all the open orders for a given tag
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->cancelMultiOrder("xyz");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApi->cancelMultiOrder: ' . $e->getMessage();
+}
+```

--- a/examples/orders/code/cancel-order-v3.md
+++ b/examples/orders/code/cancel-order-v3.md
@@ -1,0 +1,22 @@
+## Cancel an open order
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApiV3(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->cancelOrder("2501211050101");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApiV3->cancelOrder: ' . $e->getMessage();
+}
+```

--- a/examples/orders/code/cancel-order.md
+++ b/examples/orders/code/cancel-order.md
@@ -1,0 +1,24 @@
+## Cancel an open order
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$orderId = '231221011081579';
+
+try {
+    $result = $apiInstance->cancelOrder($orderId, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApi->cancelOrder: ' . $e->getMessage();
+}
+```

--- a/examples/orders/code/exit-all-positions.md
+++ b/examples/orders/code/exit-all-positions.md
@@ -1,0 +1,68 @@
+## Exit all the open positions
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->exitPositions();
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApi->exitPositions: ' . $e->getMessage();
+}
+```
+
+## Exit all the open positions for a given segment
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->exitPositions(null, "NSE_FO");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApi->exitPositions: ' . $e->getMessage();
+}
+```
+
+## Exit all the open positions for a given tag
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->exitPositions("xyz");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApi->exitPositions: ' . $e->getMessage();
+}
+```

--- a/examples/orders/code/get-historical-trades.md
+++ b/examples/orders/code/get-historical-trades.md
@@ -1,0 +1,45 @@
+## Get trade history for equity segment
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\PostTradeApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->getTradesByDateRange("2023-04-01", "2025-03-31", 1, 1000, "EQ");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling PostTradeApi->getTradesByDateRange: ' . $e->getMessage();
+}
+```
+
+## Get trade history for futures and options segment
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\PostTradeApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->getTradesByDateRange("2023-04-01", "2025-03-31", 1, 1000, "FO");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling PostTradeApi->getTradesByDateRange: ' . $e->getMessage();
+}
+```

--- a/examples/orders/code/get-order-book.md
+++ b/examples/orders/code/get-order-book.md
@@ -1,0 +1,22 @@
+## Get all orders for the day
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->getOrderBook('2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApi->getOrderBook: ' . $e->getMessage();
+}
+```

--- a/examples/orders/code/get-order-details.md
+++ b/examples/orders/code/get-order-details.md
@@ -1,0 +1,22 @@
+## Get order details for an order number
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->getOrderStatus("2410170106208487");
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApi->getOrderStatus: ' . $e->getMessage();
+}
+```

--- a/examples/orders/code/get-order-history.md
+++ b/examples/orders/code/get-order-history.md
@@ -1,0 +1,24 @@
+## Get order history for an order number
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$orderId = '240112010371054';
+
+try {
+    $result = $apiInstance->getOrderDetails('2.0', $orderId);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApi->getOrderDetails: ' . $e->getMessage();
+}
+```

--- a/examples/orders/code/get-order-trades.md
+++ b/examples/orders/code/get-order-trades.md
@@ -1,0 +1,24 @@
+## Get trades for an order number
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$orderId = '{your_order_id}';
+
+try {
+    $result = $apiInstance->getTradesByOrder($orderId, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApi->getTradesByOrder: ' . $e->getMessage();
+}
+```

--- a/examples/orders/code/get-trades.md
+++ b/examples/orders/code/get-trades.md
@@ -1,0 +1,22 @@
+## Get all trades for the day
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->getTradeHistory('2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApi->getTradeHistory: ' . $e->getMessage();
+}
+```

--- a/examples/orders/code/modify-order-v3.md
+++ b/examples/orders/code/modify-order-v3.md
@@ -1,0 +1,31 @@
+## Modify a delivery order
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApiV3(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$body = new \Upstox\Client\Model\ModifyOrderRequest();
+$body->setQuantity(1);
+$body->setValidity("DAY");
+$body->setPrice(9.12);
+$body->setOrderId("25030310405859");
+$body->setOrderType("LIMIT");
+$body->setDisclosedQuantity(0);
+$body->setTriggerPrice(0.0);
+
+try {
+    $result = $apiInstance->modifyOrder($body);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApiV3->modifyOrder: ' . $e->getMessage();
+}
+```

--- a/examples/orders/code/modify-order.md
+++ b/examples/orders/code/modify-order.md
@@ -1,0 +1,31 @@
+## Modify a delivery order
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$body = new \Upstox\Client\Model\ModifyOrderRequest();
+$body->setQuantity(2);
+$body->setValidity("DAY");
+$body->setPrice(0.0);
+$body->setOrderId("231222010275930");
+$body->setOrderType("MARKET");
+$body->setDisclosedQuantity(0);
+$body->setTriggerPrice(0.0);
+
+try {
+    $result = $apiInstance->modifyOrder($body, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApi->modifyOrder: ' . $e->getMessage();
+}
+```

--- a/examples/orders/code/place-multi-order.md
+++ b/examples/orders/code/place-multi-order.md
@@ -1,0 +1,128 @@
+## Place a multi order
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$order1 = new \Upstox\Client\Model\MultiOrderRequest();
+$order1->setQuantity(25);
+$order1->setProduct("D");
+$order1->setValidity("DAY");
+$order1->setPrice(0.0);
+$order1->setTag("string");
+$order1->setSlice(false);
+$order1->setInstrumentToken("NSE_FO|44166");
+$order1->setOrderType("MARKET");
+$order1->setTransactionType("BUY");
+$order1->setDisclosedQuantity(0);
+$order1->setTriggerPrice(0.0);
+$order1->setIsAmo(true);
+$order1->setCorrelationId("1");
+
+try {
+    $result = $apiInstance->placeMultiOrder([$order1]);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApi->placeMultiOrder: ' . $e->getMessage();
+}
+```
+
+## Place Multiple BUY and SELL Orders
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$order1 = new \Upstox\Client\Model\MultiOrderRequest();
+$order1->setQuantity(25);
+$order1->setProduct("D");
+$order1->setValidity("DAY");
+$order1->setPrice(0.0);
+$order1->setTag("string");
+$order1->setSlice(false);
+$order1->setInstrumentToken("NSE_FO|44166");
+$order1->setOrderType("MARKET");
+$order1->setTransactionType("BUY");
+$order1->setDisclosedQuantity(0);
+$order1->setTriggerPrice(0.0);
+$order1->setIsAmo(true);
+$order1->setCorrelationId("1");
+
+$order2 = new \Upstox\Client\Model\MultiOrderRequest();
+$order2->setQuantity(25);
+$order2->setProduct("D");
+$order2->setValidity("DAY");
+$order2->setPrice(0.0);
+$order2->setTag("string");
+$order2->setSlice(false);
+$order2->setInstrumentToken("NSE_FO|44122");
+$order2->setOrderType("MARKET");
+$order2->setTransactionType("SELL");
+$order2->setDisclosedQuantity(0);
+$order2->setTriggerPrice(0.0);
+$order2->setIsAmo(true);
+$order2->setCorrelationId("2");
+
+try {
+    $result = $apiInstance->placeMultiOrder([$order1, $order2]);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApi->placeMultiOrder: ' . $e->getMessage();
+}
+```
+
+## Place Multiple Orders with Auto Slicing enabled
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$order1 = new \Upstox\Client\Model\MultiOrderRequest();
+$order1->setQuantity(25);
+$order1->setProduct("D");
+$order1->setValidity("DAY");
+$order1->setPrice(0.0);
+$order1->setTag("string");
+$order1->setSlice(true);
+$order1->setInstrumentToken("NSE_FO|44166");
+$order1->setOrderType("MARKET");
+$order1->setTransactionType("BUY");
+$order1->setDisclosedQuantity(0);
+$order1->setTriggerPrice(0.0);
+$order1->setIsAmo(true);
+$order1->setCorrelationId("1");
+
+try {
+    $result = $apiInstance->placeMultiOrder([$order1]);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApi->placeMultiOrder: ' . $e->getMessage();
+}
+```

--- a/examples/orders/code/place-order-v3.md
+++ b/examples/orders/code/place-order-v3.md
@@ -1,0 +1,73 @@
+## Place an order with slicing enabled
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApiV3(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$body = new \Upstox\Client\Model\PlaceOrderV3Request();
+$body->setQuantity(4000);
+$body->setProduct("D");
+$body->setValidity("DAY");
+$body->setPrice(0.0);
+$body->setTag("string");
+$body->setInstrumentToken("NSE_FO|43919");
+$body->setOrderType("MARKET");
+$body->setTransactionType("BUY");
+$body->setDisclosedQuantity(0);
+$body->setTriggerPrice(0.0);
+$body->setIsAmo(false);
+$body->setSlice(true);
+
+try {
+    $result = $apiInstance->placeOrder($body);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApiV3->placeOrder: ' . $e->getMessage();
+}
+```
+
+## Place an order with slicing disabled
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApiV3(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$body = new \Upstox\Client\Model\PlaceOrderV3Request();
+$body->setQuantity(75);
+$body->setProduct("D");
+$body->setValidity("DAY");
+$body->setPrice(0.0);
+$body->setTag("string");
+$body->setInstrumentToken("NSE_FO|43919");
+$body->setOrderType("MARKET");
+$body->setTransactionType("BUY");
+$body->setDisclosedQuantity(0);
+$body->setTriggerPrice(0.0);
+$body->setIsAmo(false);
+$body->setSlice(false);
+
+try {
+    $result = $apiInstance->placeOrder($body);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApiV3->placeOrder: ' . $e->getMessage();
+}
+```

--- a/examples/orders/code/place-order.md
+++ b/examples/orders/code/place-order.md
@@ -1,0 +1,323 @@
+## Place a delivery market order
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$body = new \Upstox\Client\Model\PlaceOrderRequest();
+$body->setQuantity(1);
+$body->setProduct("D");
+$body->setValidity("DAY");
+$body->setPrice(0.0);
+$body->setTag("string");
+$body->setInstrumentToken("NSE_EQ|INE528G01035");
+$body->setOrderType("MARKET");
+$body->setTransactionType("BUY");
+$body->setDisclosedQuantity(0);
+$body->setTriggerPrice(0.0);
+$body->setIsAmo(false);
+
+try {
+    $result = $apiInstance->placeOrder($body, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApi->placeOrder: ' . $e->getMessage();
+}
+```
+
+## Place a delivery limit order
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$body = new \Upstox\Client\Model\PlaceOrderRequest();
+$body->setQuantity(1);
+$body->setProduct("D");
+$body->setValidity("DAY");
+$body->setPrice(20.0);
+$body->setTag("string");
+$body->setInstrumentToken("NSE_EQ|INE528G01035");
+$body->setOrderType("LIMIT");
+$body->setTransactionType("BUY");
+$body->setDisclosedQuantity(0);
+$body->setTriggerPrice(20.1);
+$body->setIsAmo(false);
+
+try {
+    $result = $apiInstance->placeOrder($body, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApi->placeOrder: ' . $e->getMessage();
+}
+```
+
+## Place a delivery stop-loss order
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$body = new \Upstox\Client\Model\PlaceOrderRequest();
+$body->setQuantity(1);
+$body->setProduct("D");
+$body->setValidity("DAY");
+$body->setPrice(20.0);
+$body->setTag("string");
+$body->setInstrumentToken("NSE_EQ|INE528G01035");
+$body->setOrderType("SL");
+$body->setTransactionType("BUY");
+$body->setDisclosedQuantity(0);
+$body->setTriggerPrice(19.5);
+$body->setIsAmo(false);
+
+try {
+    $result = $apiInstance->placeOrder($body, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApi->placeOrder: ' . $e->getMessage();
+}
+```
+
+## Place a delivery stop-loss order market
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$body = new \Upstox\Client\Model\PlaceOrderRequest();
+$body->setQuantity(1);
+$body->setProduct("D");
+$body->setValidity("DAY");
+$body->setPrice(0.0);
+$body->setTag("string");
+$body->setInstrumentToken("NSE_EQ|INE528G01035");
+$body->setOrderType("SL-M");
+$body->setTransactionType("BUY");
+$body->setDisclosedQuantity(0);
+$body->setTriggerPrice(21.5);
+$body->setIsAmo(false);
+
+try {
+    $result = $apiInstance->placeOrder($body, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApi->placeOrder: ' . $e->getMessage();
+}
+```
+
+## Place an intraday market order
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$body = new \Upstox\Client\Model\PlaceOrderRequest();
+$body->setQuantity(1);
+$body->setProduct("I");
+$body->setValidity("DAY");
+$body->setPrice(0.0);
+$body->setTag("string");
+$body->setInstrumentToken("NSE_EQ|INE528G01035");
+$body->setOrderType("MARKET");
+$body->setTransactionType("BUY");
+$body->setDisclosedQuantity(0);
+$body->setTriggerPrice(0.0);
+$body->setIsAmo(false);
+
+try {
+    $result = $apiInstance->placeOrder($body, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApi->placeOrder: ' . $e->getMessage();
+}
+```
+
+## Place an intraday limit order
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$body = new \Upstox\Client\Model\PlaceOrderRequest();
+$body->setQuantity(1);
+$body->setProduct("I");
+$body->setValidity("DAY");
+$body->setPrice(20.0);
+$body->setTag("string");
+$body->setInstrumentToken("NSE_EQ|INE528G01035");
+$body->setOrderType("LIMIT");
+$body->setTransactionType("BUY");
+$body->setDisclosedQuantity(0);
+$body->setTriggerPrice(20.1);
+$body->setIsAmo(false);
+
+try {
+    $result = $apiInstance->placeOrder($body, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApi->placeOrder: ' . $e->getMessage();
+}
+```
+
+## Place an intraday stop-loss order
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$body = new \Upstox\Client\Model\PlaceOrderRequest();
+$body->setQuantity(1);
+$body->setProduct("I");
+$body->setValidity("DAY");
+$body->setPrice(20.0);
+$body->setTag("string");
+$body->setInstrumentToken("NSE_EQ|INE528G01035");
+$body->setOrderType("SL");
+$body->setTransactionType("BUY");
+$body->setDisclosedQuantity(0);
+$body->setTriggerPrice(19.5);
+$body->setIsAmo(false);
+
+try {
+    $result = $apiInstance->placeOrder($body, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApi->placeOrder: ' . $e->getMessage();
+}
+```
+
+## Place an intraday stop-loss market order
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$body = new \Upstox\Client\Model\PlaceOrderRequest();
+$body->setQuantity(1);
+$body->setProduct("I");
+$body->setValidity("DAY");
+$body->setPrice(0.0);
+$body->setTag("string");
+$body->setInstrumentToken("NSE_EQ|INE528G01035");
+$body->setOrderType("SL-M");
+$body->setTransactionType("BUY");
+$body->setDisclosedQuantity(0);
+$body->setTriggerPrice(21.5);
+$body->setIsAmo(false);
+
+try {
+    $result = $apiInstance->placeOrder($body, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApi->placeOrder: ' . $e->getMessage();
+}
+```
+
+## Place a delivery market amo (after market order)
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\OrderApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$body = new \Upstox\Client\Model\PlaceOrderRequest();
+$body->setQuantity(1);
+$body->setProduct("D");
+$body->setValidity("DAY");
+$body->setPrice(0.0);
+$body->setTag("string");
+$body->setInstrumentToken("NSE_EQ|INE528G01035");
+$body->setOrderType("MARKET");
+$body->setTransactionType("BUY");
+$body->setDisclosedQuantity(0);
+$body->setTriggerPrice(0.0);
+$body->setIsAmo(true);
+
+try {
+    $result = $apiInstance->placeOrder($body, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling OrderApi->placeOrder: ' . $e->getMessage();
+}
+```

--- a/examples/portfolio/README.md
+++ b/examples/portfolio/README.md
@@ -1,0 +1,20 @@
+# Portfolio – Example code
+
+Links to all portfolio-related examples in the `code/` folder.
+
+## 1. Get Positions
+
+- 1.1 [Get user positions](code/get-positions.md#get-user-positions)
+
+## 2. Get MTF Positions
+
+- 2.1 [Get user MTF positions](code/get-mtf-positions.md#get-user-mtf-positions)
+
+## 3. Convert Positions
+
+- 3.1 [Convert a position from intraday to delivery](code/convert-positions.md#convert-a-position-from-intraday-to-delivery)
+- 3.2 [Convert a position from delivery to intraday](code/convert-positions.md#convert-a-position-from-delivery-to-intraday)
+
+## 4. Get Holdings
+
+- 4.1 [Get user holdings](code/get-holdings.md#get-user-holdings)

--- a/examples/portfolio/code/convert-positions.md
+++ b/examples/portfolio/code/convert-positions.md
@@ -1,0 +1,59 @@
+## Convert a position from intraday to delivery
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\PortfolioApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$body = new \Upstox\Client\Model\ConvertPositionRequest();
+$body->setInstrumentToken("NSE_EQ|INE528G01035");
+$body->setQuantity(1);
+$body->setNewProduct("D");
+$body->setOldProduct("I");
+$body->setTransactionType("BUY");
+
+try {
+    $result = $apiInstance->convertPositions($body, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling PortfolioApi->convertPositions: ' . $e->getMessage();
+}
+```
+
+## Convert a position from delivery to intraday
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\PortfolioApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$body = new \Upstox\Client\Model\ConvertPositionRequest();
+$body->setInstrumentToken("NSE_EQ|INE528G01035");
+$body->setQuantity(1);
+$body->setNewProduct("I");
+$body->setOldProduct("D");
+$body->setTransactionType("BUY");
+
+try {
+    $result = $apiInstance->convertPositions($body, '2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling PortfolioApi->convertPositions: ' . $e->getMessage();
+}
+```

--- a/examples/portfolio/code/get-holdings.md
+++ b/examples/portfolio/code/get-holdings.md
@@ -1,0 +1,22 @@
+## Get user holdings
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\PortfolioApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->getHoldings('2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling PortfolioApi->getHoldings: ' . $e->getMessage();
+}
+```

--- a/examples/portfolio/code/get-mtf-positions.md
+++ b/examples/portfolio/code/get-mtf-positions.md
@@ -1,0 +1,22 @@
+## Get user MTF positions
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\PortfolioApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->getMtfPositions();
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling PortfolioApi->getMtfPositions: ' . $e->getMessage();
+}
+```

--- a/examples/portfolio/code/get-positions.md
+++ b/examples/portfolio/code/get-positions.md
@@ -1,0 +1,22 @@
+## Get user positions
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\PortfolioApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->getPositions('2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling PortfolioApi->getPositions: ' . $e->getMessage();
+}
+```

--- a/examples/trade-profit-and-loss/README.md
+++ b/examples/trade-profit-and-loss/README.md
@@ -1,0 +1,16 @@
+# Trade Profit and Loss – Example code
+
+Links to all trade-profit-and-loss-related examples in the `code/` folder.
+
+## 1. Get Report Meta Data
+
+- 1.1 [Get report meta data for equity segment](code/get-report-meta-data.md#get-report-meta-data-for-equity-segment)
+
+## 2. Get Profit Loss Report
+
+- 2.1 [Get profit loss report for futures and options segment](code/get-profit-loss-report.md#get-profit-loss-report-for-futures-and-options-segment)
+
+## 3. Get Trade Charges
+
+- 3.1 [Get trade charges for equity segment](code/get-trade-charges.md#get-trade-charges-for-equity-segment)
+- 3.2 [Get trade charges for futures and options segment](code/get-trade-charges.md#get-trade-charges-for-futures-and-options-segment)

--- a/examples/trade-profit-and-loss/code/get-profit-loss-report.md
+++ b/examples/trade-profit-and-loss/code/get-profit-loss-report.md
@@ -1,0 +1,29 @@
+## Get profit loss report for futures and options segment
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\TradeProfitAndLossApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$segment = 'FO';
+$financialYear = '2324';
+$pageNumber = 1;
+$pageSize = 4;
+$fromDate = '02-04-2023';
+$toDate = '20-03-2024';
+
+try {
+    $result = $apiInstance->getTradeWiseProfitAndLossData($segment, $financialYear, $pageNumber, $pageSize, '2.0', $fromDate, $toDate);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling TradeProfitAndLossApi->getTradeWiseProfitAndLossData: ' . $e->getMessage();
+}
+```

--- a/examples/trade-profit-and-loss/code/get-report-meta-data.md
+++ b/examples/trade-profit-and-loss/code/get-report-meta-data.md
@@ -1,0 +1,27 @@
+## Get report meta data for equity segment
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\TradeProfitAndLossApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$segment = 'EQ';
+$financialYear = '2324';
+$fromDate = '02-04-2023';
+$toDate = '20-03-2024';
+
+try {
+    $result = $apiInstance->getTradeWiseProfitAndLossMetaData($segment, $financialYear, '2.0', $fromDate, $toDate);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling TradeProfitAndLossApi->getTradeWiseProfitAndLossMetaData: ' . $e->getMessage();
+}
+```

--- a/examples/trade-profit-and-loss/code/get-trade-charges.md
+++ b/examples/trade-profit-and-loss/code/get-trade-charges.md
@@ -1,0 +1,55 @@
+## Get trade charges for equity segment
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\TradeProfitAndLossApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$segment = 'EQ';
+$financialYear = '2324';
+$fromDate = '02-04-2023';
+$toDate = '20-03-2024';
+
+try {
+    $result = $apiInstance->getProfitAndLossCharges($segment, $financialYear, '2.0', $fromDate, $toDate);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling TradeProfitAndLossApi->getProfitAndLossCharges: ' . $e->getMessage();
+}
+```
+
+## Get trade charges for futures and options segment
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\TradeProfitAndLossApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$segment = 'FO';
+$financialYear = '2324';
+$fromDate = '02-04-2023';
+$toDate = '20-03-2024';
+
+try {
+    $result = $apiInstance->getProfitAndLossCharges($segment, $financialYear, '2.0', $fromDate, $toDate);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling TradeProfitAndLossApi->getProfitAndLossCharges: ' . $e->getMessage();
+}
+```

--- a/examples/user/README.md
+++ b/examples/user/README.md
@@ -1,0 +1,13 @@
+# User – Example code
+
+Links to all user-related examples in the `code/` folder.
+
+## 1. Get Profile
+
+- 1.1 [Get user profile information using access token](code/get-profile.md#get-user-profile-information-using-access-token)
+
+## 2. Get Fund and Margin
+
+- 2.1 [Get equity and commodity funds](code/get-fund-and-margin.md#get-equity-and-commodity-funds)
+- 2.2 [Get equity funds](code/get-fund-and-margin.md#get-equity-funds)
+- 2.3 [Get commodity funds](code/get-fund-and-margin.md#get-commodity-funds)

--- a/examples/user/code/get-fund-and-margin.md
+++ b/examples/user/code/get-fund-and-margin.md
@@ -1,0 +1,72 @@
+## Get equity and commodity funds
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\UserApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->getUserFundMargin('2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling UserApi->getUserFundMargin: ' . $e->getMessage();
+}
+```
+
+## Get equity funds
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\UserApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$segment = 'SEC';
+
+try {
+    $result = $apiInstance->getUserFundMargin('2.0', $segment);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling UserApi->getUserFundMargin: ' . $e->getMessage();
+}
+```
+
+## Get commodity funds
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\UserApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+$segment = 'COM';
+
+try {
+    $result = $apiInstance->getUserFundMargin('2.0', $segment);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling UserApi->getUserFundMargin: ' . $e->getMessage();
+}
+```

--- a/examples/user/code/get-profile.md
+++ b/examples/user/code/get-profile.md
@@ -1,0 +1,22 @@
+## Get user profile information using access token
+
+
+```php
+<?php
+
+$accessToken = '{your_access_token}';
+$config = Upstox\Client\Configuration::getDefaultConfiguration()
+    ->setAccessToken($accessToken);
+
+$apiInstance = new Upstox\Client\Api\UserApi(
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->getProfile('2.0');
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling UserApi->getProfile: ' . $e->getMessage();
+}
+```


### PR DESCRIPTION
- Implemented cancel order functionality for both v3 and v1 APIs.
- Added examples for exiting all open positions with optional segment and tag filters.
- Created examples for retrieving historical trades for both equity and futures/options segments.
- Added functionality to get order book and order details.
- Implemented examples for fetching order history and trades associated with an order.
- Added examples for placing and modifying orders, including multi-order placements with slicing options.
- Created examples for portfolio management, including getting positions, MTF positions, and holdings.
- Added trade profit and loss examples, including fetching report metadata and trade charges for both equity and futures/options segments.
- Implemented user-related examples for fetching user profile and fund/margin information.